### PR TITLE
Changes for common "accuknox-agents" namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,23 +39,23 @@ This will install all the components.
 
  
 ```
-NAMESPACE     NAME                                             READY   STATUS      RESTARTS   AGE
-kube-system   helm-install-traefik-crd-gwlpt                   0/1     Completed   0          3h17m
-kube-system   helm-install-traefik-lzkqg                       0/1     Completed   1          3h17m
-kube-system   svclb-traefik-47bc4                              2/2     Running     2          3h9m
-kube-system   metrics-server-86cbb8457f-cw9jd                  1/1     Running     1          3h9m
-kube-system   local-path-provisioner-7c7846d5f8-kxdxj          1/1     Running     1          3h3m
-kube-system   coredns-7448499f4d-qk6pv                         1/1     Running     0          15m
-kube-system   traefik-5ffb8d6846-w8clc                         1/1     Running     1          3h3m
-kube-system   cilium-operator-6bbdb895b5-ff752                 1/1     Running     0          12m
-kube-system   hubble-relay-84999fcb48-8d5ss                    1/1     Running     0          11m
-kube-system   cilium-wkgzn                                     1/1     Running     0          11m
-accuknox-agents      mysql-0                                          1/1     Running     0          10m
-kube-system   kubearmor-67jtk                                  1/1     Running     0          8m34s
-kube-system   kubearmor-policy-manager-986bd8dbc-4s79d         2/2     Running     0          8m34s
-kube-system   kubearmor-host-policy-manager-5bcccfc4f5-gkbck   2/2     Running     0          8m34s
-kube-system   kubearmor-relay-645667c695-brzpg                 1/1     Running     0          8m34s
-accuknox-agents      knoxautopolicy-6bf6c98dbb-pfwt9                  1/1     Running     0          8m20s
+NAMESPACE         NAME                                                   READY   STATUS    RESTARTS   AGE
+accuknox-agents   cilium-gke-node-init-l9c6f                             1/1     Running   0          14m
+accuknox-agents   cilium-gke-node-init-wmsst                             1/1     Running   0          14m
+accuknox-agents   cilium-gke-node-init-wqb5z                             1/1     Running   0          14m
+accuknox-agents   cilium-l8qg9                                           1/1     Running   0          13m
+accuknox-agents   cilium-n287r                                           1/1     Running   0          13m
+accuknox-agents   cilium-operator-776958f5bb-vvc72                       1/1     Running   0          14m
+accuknox-agents   cilium-xt4bh                                           1/1     Running   0          13m
+accuknox-agents   hubble-relay-7c46d49cc5-pfk8h                          1/1     Running   0          12m
+accuknox-agents   knoxautopolicy-6bf6c98dbb-pfwt9                        1/1     Running   0          8m51s
+accuknox-agents   kubearmor-dxc7d                                        1/1     Running   0          9m5s
+accuknox-agents   kubearmor-host-policy-manager-5bcccfc4f5-lvdkd         2/2     Running   0          9m4s
+accuknox-agents   kubearmor-jkfsf                                        1/1     Running   0          9m5s
+accuknox-agents   kubearmor-nc6l6                                        1/1     Running   0          9m5s
+accuknox-agents   kubearmor-policy-manager-986bd8dbc-8cdch               2/2     Running   0          9m4s
+accuknox-agents   kubearmor-relay-645667c695-97nq6                       1/1     Running   0          9m5s
+accuknox-agents   mysql-0                                                1/1     Running   0          11m
 ```
 
 We have following installed:

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ This install instructions allow you to setup sample cluster with:
 
 <details>
   <summary>Using k3s local cluster</summary>
-  
+
 #### Install k3s
-    
+
 ```
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='--flannel-backend=none --disable traefik' sh -s - --write-kubeconfig-mode 644
 ```
-    
+
 #### Make k3s cluster config the default
 
 ```
@@ -50,14 +50,14 @@ kube-system   traefik-5ffb8d6846-w8clc                         1/1     Running  
 kube-system   cilium-operator-6bbdb895b5-ff752                 1/1     Running     0          12m
 kube-system   hubble-relay-84999fcb48-8d5ss                    1/1     Running     0          11m
 kube-system   cilium-wkgzn                                     1/1     Running     0          11m
-explorer      mysql-0                                          1/1     Running     0          10m
+accuknox-agents      mysql-0                                          1/1     Running     0          10m
 kube-system   kubearmor-67jtk                                  1/1     Running     0          8m34s
 kube-system   kubearmor-policy-manager-986bd8dbc-4s79d         2/2     Running     0          8m34s
 kube-system   kubearmor-host-policy-manager-5bcccfc4f5-gkbck   2/2     Running     0          8m34s
 kube-system   kubearmor-relay-645667c695-brzpg                 1/1     Running     0          8m34s
-explorer      knoxautopolicy-6bf6c98dbb-pfwt9                  1/1     Running     0          8m20s
+accuknox-agents      knoxautopolicy-6bf6c98dbb-pfwt9                  1/1     Running     0          8m20s
 ```
-    
+
 We have following installed:
 * kubearmor protection engine
 * cilium CNI
@@ -81,7 +81,7 @@ kubectl apply -f https://raw.githubusercontent.com/kubearmor/KubeArmor/main/exam
 
 <details>
   <summary>Google "Online Boutique" Microservice Demo App</summary>
-    
+
 [Application Reference](https://github.com/GoogleCloudPlatform/microservices-demo)
 
 ```
@@ -102,10 +102,10 @@ curl -s https://raw.githubusercontent.com/accuknox/tools/main/get_discovered_yam
 ❯ curl -s https://raw.githubusercontent.com/accuknox/tools/main/get_discovered_yamls.sh | bash
 Downloading discovered policies from pod=knoxautopolicy-6bf6c98dbb-pfwt9
 Got 38 cilium policies for namespace=default in file cilium_policies_default.yaml
-Got 4 cilium policies for namespace=explorer in file cilium_policies_explorer.yaml
+Got 4 cilium policies for namespace=accuknox-agents in file cilium_policies_accuknox-agents.yaml
 Got 13 cilium policies for namespace=kube-system in file cilium_policies_kube-system.yaml
 Got 38 knox policies for namespace=default in file knox_net_policies_default.yaml
-Got 4 knox policies for namespace=explorer in file knox_net_policies_explorer.yaml
+Got 4 knox policies for namespace=accuknox-agents in file knox_net_policies_accuknox-agents.yaml
 Got 13 knox policies for namespace=kube-system in file knox_net_policies_kube-system.yaml
 Got 146 kubearmor policies in file kubearmor_policies.yaml
 ```

--- a/common.sh
+++ b/common.sh
@@ -125,7 +125,11 @@ handleKnoxAutoPolicy()
 
 	statusline WAIT "$1 knoxautopolicy"
 	kubectl $1 -f $KNOXAUTOPOLICY_SVC
-	kubectl $1 -f $KNOXAUTOPOLICY_CFG
+	curl -s https://raw.githubusercontent.com/accuknox/auto-policy-discovery/dev/deployments/k8s/dev-config.yaml -o cm-dev-config.yaml
+	sed -i -e "s/db|file/db/; s/explorer/accuknox-agents/; s/kube-system/accuknox-agents/" cm-dev-config.yaml
+#	kubectl $1 -f $KNOXAUTOPOLICY_CFG
+	kubectl $1 -f cm-dev-config.yaml --namespace accuknox-agents
+	rm cm-dev-config.yaml
 	kubectl $1 -f $KNOXAUTOPOLICY_DEP
 	kubectl $1 -f $KNOXAUTOPOLICY_SA
 	statusline AOK "$1 knoxautopolicy"

--- a/common.sh
+++ b/common.sh
@@ -49,7 +49,7 @@ autoDetectEnvironment(){
 
 annotate()
 {
-	ns_ignore_list=("kube-system" "explorer" "cilium" "kubearmor")
+	ns_ignore_list=("kube-system" "accuknox-agents" "cilium" "kubearmor")
 	while read line; do
 		depnm=${line/ */}
 		depns=${line/* /}
@@ -73,7 +73,7 @@ handleKubearmor(){
 		if [ $? -eq 0 ]; then
 			statusline AOK "skipping ... existing kubearmor installation found"
 		else
-			karmor install ${KA_INSTALL_OPTS}
+			karmor install --namespace accuknox-agents # ${KA_INSTALL_OPTS}
 			statusline $? "$1 kubearmor"
 		fi
 		# applyKubearmorVisibility	# This is not needed with latest kubearmor
@@ -81,7 +81,7 @@ handleKubearmor(){
 	fi
 	karmor version | grep "kubearmor image (running)" >/dev/null
 	[[ $? -ne 0 ]] && statusline AOK "skipping ... kubearmor installation not found" && return 0
-	karmor uninstall
+	karmor uninstall --namespace accuknox-agents
 	statusline $? "$1 kubearmor"
 	: << "END"
 	case $PLATFORM in
@@ -118,10 +118,10 @@ handleKnoxAutoPolicy()
 		statusline AOK "knoxautopolicy already installed" && return 0
 	[[ "$1" == "delete" ]] && [[ $kap_install -ne 0 ]] && return 0
 	KNOXAUTOPOLICY_REPO="https://raw.githubusercontent.com/accuknox/auto-policy-discovery/dev/deployments/k8s"
-	KNOXAUTOPOLICY_SVC="$KNOXAUTOPOLICY_REPO/service.yaml --namespace explorer"
-	KNOXAUTOPOLICY_CFG="$KNOXAUTOPOLICY_REPO/dev-config.yaml --namespace explorer"
-	KNOXAUTOPOLICY_DEP="$KNOXAUTOPOLICY_REPO/deployment.yaml --namespace explorer"
-	KNOXAUTOPOLICY_SA="$KNOXAUTOPOLICY_REPO/serviceaccount.yaml --namespace explorer"
+	KNOXAUTOPOLICY_SVC="$KNOXAUTOPOLICY_REPO/service.yaml --namespace accuknox-agents"
+	KNOXAUTOPOLICY_CFG="$KNOXAUTOPOLICY_REPO/dev-config.yaml --namespace accuknox-agents"
+	KNOXAUTOPOLICY_DEP="$KNOXAUTOPOLICY_REPO/deployment.yaml --namespace accuknox-agents"
+	KNOXAUTOPOLICY_SA="$KNOXAUTOPOLICY_REPO/serviceaccount.yaml --namespace accuknox-agents"
 
 	statusline WAIT "$1 knoxautopolicy"
 	kubectl $1 -f $KNOXAUTOPOLICY_SVC

--- a/feeder/values.yaml
+++ b/feeder/values.yaml
@@ -71,7 +71,7 @@ env:
  - name: MYSQL_PASSWORD
    value: password 
  - name: MYSQL_URL
-   value: mysql.explorer.svc.cluster.local 
+   value: mysql.accuknox-agents.svc.cluster.local 
  - name: MYSQL_PORT
    value: 3306
  - name: MYSQL_DATABASE

--- a/feeder/values.yaml
+++ b/feeder/values.yaml
@@ -71,7 +71,7 @@ env:
  - name: MYSQL_PASSWORD
    value: password 
  - name: MYSQL_URL
-   value: mysql.accuknox-agents.svc.cluster.local 
+   value: mysql.explorer.svc.cluster.local 
  - name: MYSQL_PORT
    value: 3306
  - name: MYSQL_DATABASE

--- a/get_discovered_yamls.sh
+++ b/get_discovered_yamls.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
 
-podname=$(kubectl get pod -n explorer -l container=knoxautopolicy -o=jsonpath='{.items[0].metadata.name}')
+podname=$(kubectl get pod -n accuknox-agents -l container=knoxautopolicy -o=jsonpath='{.items[0].metadata.name}')
 [[ $? -ne 0 ]] && echo "could not find knoxautopolicy pod" && exit 2
 echo "Downloading discovered policies from pod=$podname"
 
 function trigger_policy_dump()
 {
-	kubectl exec -n explorer $podname -- ls /convert_$1_policy.sh 2>&1 >/dev/null
-	[[ $? -eq 0 ]] && kubectl exec -n explorer $podname -- /convert_$1_policy.sh
+	kubectl exec -n accuknox-agents $podname -- ls /convert_$1_policy.sh 2>&1 >/dev/null
+	[[ $? -eq 0 ]] && kubectl exec -n accuknox-agents $podname -- /convert_$1_policy.sh
 }
 
 function network_policy()
 {
 	trigger_policy_dump net
-	filelist=`kubectl exec -n explorer $podname -- ls -1 | grep "cilium_policies.*\.yaml"`
+	filelist=`kubectl exec -n accuknox-agents $podname -- ls -1 | grep "cilium_policies.*\.yaml"`
 	[[ "$filelist" == "" ]] && echo "No network policies discovered" && return
 	for f in `echo $filelist`; do
 		f=$(echo $f | tr -d '\r')
 		typ=${f/_*/}
 		ns=${f/*_policies_/}
 		ns=${ns/.yaml/}
-		kubectl cp explorer/$podname:$f $f
+		kubectl cp accuknox-agents/$podname:$f $f
 		cnt=`grep "kind:" $f | wc -l`
 		echo "Got $cnt $typ policies for namespace=$ns in file $f"
 	done
@@ -29,12 +29,12 @@ function network_policy()
 function system_policy()
 {
 	trigger_policy_dump sys
-	filelist=`kubectl exec -n explorer $podname -- ls -1 | grep "kubearmor_policies\.yaml"`
+	filelist=`kubectl exec -n accuknox-agents $podname -- ls -1 | grep "kubearmor_policies\.yaml"`
 	[[ "$filelist" == "" ]] && echo "No system policies discovered" && return 1
 	for f in `echo $filelist`; do
 		f=$(echo $f | tr -d '\r')
 		typ=${f/_*/}
-		kubectl cp explorer/$podname:$f $f
+		kubectl cp accuknox-agents/$podname:$f $f
 		cnt=`grep "kind:" $f | wc -l`
 		echo "Got $cnt $typ policies in file $f"
 	done

--- a/policy-discovery.md
+++ b/policy-discovery.md
@@ -37,10 +37,10 @@ Typical output:
 ```
 ❯ ./get_discovered_yamls.sh
 Downloading discovered policies from pod=knoxautopolicy-74f5b5d65b-tv7v7
-Got 9 cilium policies for namespace=explorer in file cilium_policies_explorer.yaml
+Got 9 cilium policies for namespace=accuknox-agents in file cilium_policies_accuknox-agents.yaml
 Got 5 cilium policies for namespace=kube-system in file cilium_policies_kube-system.yaml
 Got 2 cilium policies for namespace=spire in file cilium_policies_spire.yaml
-Got 9 knox policies for namespace=explorer in file knox_policies_explorer.yaml
+Got 9 knox policies for namespace=accuknox-agents in file knox_policies_accuknox-agents.yaml
 Got 5 knox policies for namespace=kube-system in file knox_policies_kube-system.yaml
 Got 2 knox policies for namespace=spire in file knox_policies_spire.yaml
 ```

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,15 +7,15 @@ else
 fi
 
 uninstallMysql() {
-	kubectl get pod -n explorer -l "app.kubernetes.io/name=mysql" | grep "mysql" >/dev/null 2>&1
+	kubectl get pod -n accuknox-agents -l "app.kubernetes.io/name=mysql" | grep "mysql" >/dev/null 2>&1
 	[[ $? -ne 0 ]] && statusline AOK "no mysql found, skipping uninstall" && return 0
 	statusline WAIT "uninstalling mysql"
-	helm uninstall mysql --namespace explorer
+	helm uninstall mysql --namespace accuknox-agents
 	statusline AOK "uninstalling mysql"
 }
 
 uninstallFeeder() {
-	helm uninstall feeder-service-cilium --namespace explorer
+	helm uninstall feeder-service-cilium --namespace accuknox-agents
 }
 
 uninstallCilium() {
@@ -28,7 +28,7 @@ uninstallCilium() {
 
 uninstallSpire() {
 	echo "uninstalling Spire"
-	helm uninstall spire --namespace explorer
+	helm uninstall spire --namespace accuknox-agents
 }
 
 autoDetectEnvironment
@@ -44,5 +44,5 @@ uninstallCilium
 #handleKubearmorPrometheusClient delete
 handleKubearmor delete
 
-kubectl get ns explorer >/dev/null 2>&1
-[[ $? -eq 0 ]] && kubectl delete ns explorer
+kubectl get ns accuknox-agents >/dev/null 2>&1
+[[ $? -eq 0 ]] && kubectl delete ns accuknox-agents


### PR DESCRIPTION
 - [x] Tested on cluster
 - [x] All pods running on `accuknox-agents` namespace [ Section: Install Daemonsets and Services ]
```sh
➜  tools git:(main) ✗ kubectl get pods -A
NAMESPACE         NAME                                                   READY   STATUS    RESTARTS   AGE
accuknox-agents   cilium-gke-node-init-l9c6f                             1/1     Running   0          14m
accuknox-agents   cilium-gke-node-init-wmsst                             1/1     Running   0          14m
accuknox-agents   cilium-gke-node-init-wqb5z                             1/1     Running   0          14m
accuknox-agents   cilium-l8qg9                                           1/1     Running   0          13m
accuknox-agents   cilium-n287r                                           1/1     Running   0          13m
accuknox-agents   cilium-operator-776958f5bb-vvc72                       1/1     Running   0          14m
accuknox-agents   cilium-xt4bh                                           1/1     Running   0          13m
accuknox-agents   hubble-relay-7c46d49cc5-pfk8h                          1/1     Running   0          12m
accuknox-agents   knoxautopolicy-74f5b5d65b-5j9w4                        1/1     Running   0          8m51s
accuknox-agents   kubearmor-dxc7d                                        1/1     Running   0          9m5s
accuknox-agents   kubearmor-host-policy-manager-5bcccfc4f5-lvdkd         2/2     Running   0          9m4s
accuknox-agents   kubearmor-jkfsf                                        1/1     Running   0          9m5s
accuknox-agents   kubearmor-nc6l6                                        1/1     Running   0          9m5s
accuknox-agents   kubearmor-policy-manager-986bd8dbc-8cdch               2/2     Running   0          9m4s
accuknox-agents   kubearmor-relay-645667c695-97nq6                       1/1     Running   0          9m5s
accuknox-agents   mysql-0                                                1/1     Running   0          11m
```
 - [x] Whether `knoxautopolicy` pod working or not [Section: Get Auto Discovered Policies]
```sh
Downloading discovered policies from pod=knoxautopolicy-74f5b5d65b-sg57w
{
  "res": "ok"
}
Got 0 cilium policies in file cilium_policies.yaml
{
  "res": "ok"
}
Got 0 kubearmor policies in file kubearmor_policies.yaml
```